### PR TITLE
Add support for custom `<body>` content in Kobweb index generation

### DIFF
--- a/frontend/kobweb-core/src/jsTest/kotlin/com/varabyte/kobweb/navigation/RouteTest.kt
+++ b/frontend/kobweb-core/src/jsTest/kotlin/com/varabyte/kobweb/navigation/RouteTest.kt
@@ -27,6 +27,7 @@ class RouteTest {
             "https://example.com/a/b/c" to "https://example.com/a/b/c",
             "https://example.com/a/b/c?key=value#frag" to "https://example.com/a/b/c?key=value#frag",
             "https://example.com/a/b/c#frag?key=value" to "https://example.com/a/b/c#frag?key=value",
+            "//example.com/a/b/c?key=value#frag" to "//example.com/a/b/c?key=value#frag",
             "/a/b/c?key=value#frag" to "/a/b/c?key=value#frag",
             "/a/b/c#frag?key=value" to "/a/b/c#frag?key=value",
             "https://example.com/?key=value" to "https://example.com/?key=value",
@@ -36,11 +37,12 @@ class RouteTest {
             "https://////example.com///?key=value" to "https://example.com/?key=value",
             "https://example.com/////a///b//c" to "https://example.com/a/b/c",
             "https://example.com///a/b//////c//////" to "https://example.com/a/b/c/",
-            "//////a////b///c//" to "/a/b/c/",
+            "//////example.com///a////b///c//" to "//example.com/a/b/c/",
 
             // Leave query params / fragments alone!
             "https://example.com/a/b/c?arg=with//slashes#with//slashes" to "https://example.com/a/b/c?arg=with//slashes#with//slashes",
             "https:////example.com//a//b//c//?arg=with//slashes#with//slashes" to "https://example.com/a/b/c/?arg=with//slashes#with//slashes",
+            "//////example.com//a//b//c//?arg=with//slashes#with//slashes" to "//example.com/a/b/c/?arg=with//slashes#with//slashes",
         )
 
         beforeAfter.forEach { (before, after) ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kobweb = "0.23.1-SNAPSHOT"
+kobweb = "0.23.2-SNAPSHOT"
 #------------------------
 commonmark = "0.25.1"
 compose = "1.8.0"

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.varabyte.kobweb.gradle.application.util.configAsKobwebApplication
 import com.varabyte.kobwebx.gradle.markdown.handlers.SilkCalloutBlockquoteHandler
+import kotlinx.html.script
+import kotlinx.html.unsafe
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -17,6 +19,26 @@ kobweb {
         index {
             interceptUrls {
                 enableSelfHosting()
+            }
+            // Test the new body block functionality
+            body.add {
+                script {
+                    src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+                    attributes["integrity"] = "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
+                    attributes["crossorigin"] = "anonymous"
+                }
+            }
+            body.add {
+                script {
+                    unsafe {
+                        raw(
+                            """
+                            // Test analytics script
+                            console.log('Body block test: Analytics script loaded');
+                        """.trimIndent()
+                        )
+                    }
+                }
             }
         }
     }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
@@ -74,6 +74,7 @@ fun createIndexFile(
     title: String,
     lang: String,
     headElements: Iterable<String>,
+    bodyElements: Iterable<String>,
     src: String,
     scriptAttributes: Map<String, String>,
     buildTarget: BuildTarget
@@ -106,6 +107,11 @@ fun createIndexFile(
                     script {
                         this.src = src
                         attributes.putAll(scriptAttributes)
+                    }
+
+                    // Add user body elements
+                    bodyElements.forEach { elements ->
+                        unsafe { raw(elements) }
                     }
                 }
             }


### PR DESCRIPTION
```
### Summary
This pull request introduces the ability to customize `<body>` elements in the Kobweb index file generation. It provides flexibility to inject custom HTML elements into the `<body>` section of the template to enhance content or functionality.

### Changelog

- Added `serializeBodyContents` utility for creating customizable content blocks.
- Enhanced the index generation process to support injecting custom content inside the `<body>` tag.
- Implemented logging for final `<body>` elements to aid in debugging.
- Added a feature to include Bootstrap and analytics scripts using the newly introduced functionality.

### Future Considerations
N/A

### Checklist for Maintainers

- [ ] Ensure backward compatibility is established.
- [ ] Validate all related tests pass successfully.
- [ ] Review and merge according to the project policies.
```